### PR TITLE
트랙 제목 오버플로우시 말줄임표 적용

### DIFF
--- a/assets/css/text.css
+++ b/assets/css/text.css
@@ -1,5 +1,5 @@
-.is-text-ellipsis{
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+.is-text-ellipsis {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -1,4 +1,4 @@
 @charset "utf-8";
 @import 'buefy.scss';
 @import '../css/layout.css';
-@import '../css/text.css'
+@import '../css/text.css';

--- a/components/rider/RecentTrackRecordList.vue
+++ b/components/rider/RecentTrackRecordList.vue
@@ -168,7 +168,7 @@ export default Vue.extend({
   height: 33px;
 }
 .track-info {
-  flex:2;
+  flex: 2;
   padding-left: 8px;
 }
 .track-info-subtitle {
@@ -177,6 +177,6 @@ export default Vue.extend({
 }
 .track-win {
   text-align: center;
-  flex:1;
+  flex: 1;
 }
 </style>


### PR DESCRIPTION
윈도우 환경에서 트랙 제목이 긴 경우 레이아웃이 깨지는 현상이 있어 트랙 제목 오버플로우시 말줄임표 적용