### PR TITLE
닉네임 변경시 전적 갱신 불가

### DIFF
--- a/pages/rider/_nickname.vue
+++ b/pages/rider/_nickname.vue
@@ -203,7 +203,7 @@ export default Vue.extend({
       this.isButtonLoading = true
       try {
         const data = await this.$api.refreshPlayerDetail(
-          this.data.nickname,
+          this.nickname,
           this.channel
         )
         if (data === null) {


### PR DESCRIPTION
데이터베이스에 변경 전 닉네임으로 되어있다면, 전정 갱신 불가능한 버그, url path의 닉네임으로 전적 갱신