### PR TITLE
채널별 플레이 횟수 x축 라벨이 [1-24]로 표시되던 버그 수정

### DIFF
--- a/src/components/stat/PlayTimeCountByChannelLine.vue
+++ b/src/components/stat/PlayTimeCountByChannelLine.vue
@@ -28,6 +28,13 @@ export default Vue.extend({
       chart: {
         type: 'line',
       },
+      xaxis: {
+        labels: {
+          formatter(value: number) {
+            return value - 1
+          },
+        },
+      },
       responsive: [
         {
           breakpoint: 480,
@@ -55,7 +62,7 @@ export default Vue.extend({
       tooltip: {
         x: {
           formatter(value: number) {
-            return `${value}시`
+            return `${value - 1}시`
           },
         },
         y: {


### PR DESCRIPTION
매치 통계에서 채널별 플레이 횟수 x축 라벨이 `[1-24]`로 표시되던 버그 수정  
올바른 라벨: `[0-23]`